### PR TITLE
Retain fixes, destroy api, update go-textile dep

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Expecta (1.0.6)
   - Protobuf (3.7.0)
   - Specta (1.0.7)
-  - Textile (0.1.3):
+  - Textile (0.1.5):
     - Protobuf (~> 3.7)
-    - TextileCore (~> 0.1.12-rc1)
-  - TextileCore (0.1.12-rc1):
+    - TextileCore (~> 0.1.12-rc3)
+  - TextileCore (0.1.12-rc3):
     - Protobuf (~> 3.7)
 
 DEPENDENCIES:
@@ -28,8 +28,8 @@ SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   Protobuf: 7a877b7f3e5964e3fce995e2eb323dbc6831bb5a
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
-  Textile: f7d6e74fe0d8f3f943b5e1731eb619b46ffe14ed
-  TextileCore: 1f0e510cf99eb5c52cc275383fccddcdd640787d
+  Textile: 42457e710b2f9d7e19e47a4c934b38ae692fe364
+  TextileCore: 757c0ee2e4c423055693a9c51ccbad58b3fd0597
 
 PODFILE CHECKSUM: 9b49a030118caed5b52efabd9fef600159fbd3ff
 

--- a/Textile.podspec
+++ b/Textile.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'Textile'
-  s.version               = '0.1.4'
+  s.version               = '0.1.5'
   s.summary               = 'Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P'
   s.description           = <<-DESC
                             The Textile pod provides iOS native access and helpers for the Textile platform.
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   # https://stackoverflow.com/questions/50024087/gomobile-bind-producing-library-with-pie-disabled-i386-arch
   s.pod_target_xcconfig   = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1', 'OTHER_LDFLAGS[arch=i386]' => '-Wl,-read_only_relocs,suppress' }
   s.dependency 'Protobuf', '~> 3.7'
-  s.dependency 'TextileCore', '~> 0.1.12-rc1'
+  s.dependency 'TextileCore', '~> 0.1.12-rc3'
 end

--- a/Textile/Classes/LifecycleManager.m
+++ b/Textile/Classes/LifecycleManager.m
@@ -42,12 +42,14 @@ typedef NS_CLOSED_ENUM(NSInteger, AppState) {
       [self processNewState:AppStateBackground];
     }
 
+    __weak LifecycleManager *weakSelf = self;
+
     [NSNotificationCenter.defaultCenter
      addObserverForName:UIApplicationDidBecomeActiveNotification
      object:nil
      queue:nil
      usingBlock:^(NSNotification *notification) {
-       [self processNewState:AppStateForeground];
+       [weakSelf processNewState:AppStateForeground];
      }];
 
     [NSNotificationCenter.defaultCenter
@@ -55,7 +57,7 @@ typedef NS_CLOSED_ENUM(NSInteger, AppState) {
      object:nil
      queue:nil
      usingBlock:^(NSNotification *notification) {
-       [self processNewState:AppStateBackground];
+       [weakSelf processNewState:AppStateBackground];
      }];
   });
 }
@@ -106,15 +108,16 @@ typedef NS_CLOSED_ENUM(NSInteger, AppState) {
 }
 
 - (void)stopNodeAfterDelay:(NSTimeInterval)delay {
+  __weak LifecycleManager *weakSelf = self;
   UIBackgroundTaskIdentifier bgTaskId = [UIApplication.sharedApplication beginBackgroundTaskWithName:@"RunNode" expirationHandler:^{
-    [self stopNode];
+    [weakSelf stopNode];
   }];
   [self.timer invalidate];
   if ([self.delegate respondsToSelector:@selector(willStopNodeInBackgroundAfterDelay:)]) {
     [self.delegate willStopNodeInBackgroundAfterDelay:delay];
   }
   self.timer = [NSTimer scheduledTimerWithTimeInterval:delay repeats:FALSE block:^(NSTimer * _Nonnull timer) {
-    [self stopNode];
+    [weakSelf stopNode];
     [UIApplication.sharedApplication endBackgroundTask:bgTaskId];
   }];
 }

--- a/Textile/Classes/NodeDependant.h
+++ b/Textile/Classes/NodeDependant.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NodeDependant : NSObject
 
-@property (nonatomic, strong) MobileMobile *node;
+@property (nonatomic, weak) MobileMobile *node;
 
 - (instancetype)initWithNode:(MobileMobile *)node;
 

--- a/Textile/Classes/TextileApi.h
+++ b/Textile/Classes/TextileApi.h
@@ -57,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)version;
 - (NSString *)gitSummary;
 - (Summary *)summary:(NSError **)error;
+- (void)destroy:(NSError **)error;
 
 @end
 


### PR DESCRIPTION
Found some memory related bugs that were causing objects to hang around in memory and cause duplicate notifications when used in the RN sdk.

Added a `destroy` method to the api that clears out all in memory references, allowing Textile to be re-initialized if needed. Mostly useful for the RN sdk for when the JS is "reloaded" during development. Upcoming PR in the RN sdk repo showing how that works.

Updated to go-textile 0.1.12-rc3.