### PR TITLE
Updates to return nil where appropriate

### DIFF
--- a/Textile.podspec
+++ b/Textile.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'Textile'
-  s.version               = '0.1.5'
+  s.version               = '0.1.6'
   s.summary               = 'Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P'
   s.description           = <<-DESC
                             The Textile pod provides iOS native access and helpers for the Textile platform.

--- a/Textile/Classes/CafesApi.m
+++ b/Textile/Classes/CafesApi.m
@@ -16,6 +16,9 @@
 
 - (CafeSession *)session:(NSString *)peerId error:(NSError * _Nullable __autoreleasing *)error {
   NSData *data = [self.node cafeSession:peerId error:error];
+  if(!data) {
+    return nil;
+  }
   return [[CafeSession alloc] initWithData:data error:error];
 }
 
@@ -26,6 +29,9 @@
 
 - (CafeSession *)refreshSession:(NSString *)peerId error:(NSError * _Nullable __autoreleasing *)error {
   NSData *data = [self.node refreshCafeSession:peerId error:error];
+  if(!data) {
+    return nil;
+  }
   return [[CafeSession alloc] initWithData:data error:error];
 }
 

--- a/Textile/Classes/ContactsApi.m
+++ b/Textile/Classes/ContactsApi.m
@@ -16,6 +16,9 @@
 
 - (Contact *)get:(NSString *)address error:(NSError * _Nullable __autoreleasing *)error {
   NSData *data = [self.node contact:address error:error];
+  if(!data) {
+    return nil;
+  }
   return [[Contact alloc] initWithData:data error:error];
 }
 

--- a/Textile/Classes/ThreadsApi.m
+++ b/Textile/Classes/ThreadsApi.m
@@ -25,6 +25,9 @@
 
 - (Thread *)get:(NSString *)threadId error:(NSError * _Nullable __autoreleasing *)error {
   NSData *data = [self.node thread:threadId error:error];
+  if(!data) {
+    return nil;
+  }
   return [[Thread alloc] initWithData:data error:error];
 }
 


### PR DESCRIPTION
Slightly different approach in Obj C to get the desired result. 

Obj C will gladly create default pb object from `nil` `NSData`, so that works great for creating empty list types. 

In the case of non-list types, we're relying on the go-textile layer to return an error if a return type that should never be `nil` is going to be `nil`.

The only work left to do as seen is this PR is to make sure we return `nil` in cases where we know it is an acceptable return value from go-textile. This is usually in cases where we're querying for something by id.