### PR TITLE
ios-textile: add swarm connect to ipfs api

### DIFF
--- a/Textile/Classes/Public/IpfsApi.h
+++ b/Textile/Classes/Public/IpfsApi.h
@@ -23,6 +23,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)peerId:(NSError **)error;
 
 /**
+ * Open a new direct connection to a peer using an IPFS multiaddr
+ * @param multiaddr Peer IPFS multiaddr
+ * @param error A reference to an error pointer that will be set in the case of an error
+ * @return Whether the peer swarm connect was successfull
+ */
+- (BOOL)swarmConnect:(NSString *)multiaddr error:(NSError **)error;
+
+/**
  * Get raw data stored at an IPFS path
  * @param path The IPFS path for the data you want to retrieve
  * @param completion A block that will get called with the results of the query

--- a/Textile/Classes/Public/IpfsApi.m
+++ b/Textile/Classes/Public/IpfsApi.m
@@ -15,6 +15,11 @@
   return [self.node peerId:error];
 }
 
+- (BOOL)swarmConnect:(NSString *)multiaddr error:(NSError * _Nullable __autoreleasing *)error {
+  NSString *result = [self.node swarmConnect:multiaddr error:error];
+  return [result length] > 0;
+}
+
 - (void)dataAtPath:(NSString *)path completion:(void (^)(NSData * _Nullable, NSString * _Nullable, NSError * _Nonnull))completion {
   DataCallback *cb = [[DataCallback alloc] initWithCompletion:^(NSData *data, NSString *media, NSError *error) {
     if (error) {

--- a/Textile/Classes/Public/TextileApi.m
+++ b/Textile/Classes/Public/TextileApi.m
@@ -75,7 +75,7 @@ NSString *const TEXTILE_BACKGROUND_SESSION_ID = @"textile";
 + (BOOL)initialize:(NSString *)repoPath seed:(NSString *)seed debug:(BOOL)debug logToDisk:(BOOL)logToDisk error:(NSError * _Nullable __autoreleasing *)error {
   MobileInitConfig *config = [[MobileInitConfig alloc] init];
   config.seed = seed;
-  config.repoPath = repoPath;
+  config.baseRepoPath = repoPath;
   config.logToDisk = logToDisk;
   config.debug = debug;
   return MobileInitRepo(config, error);


### PR DESCRIPTION
Add `swarm connect` to [Update React Native APIs to match more closely the JS and Rest API](https://github.com/textileio/react-native-sdk/issues/108)

Need PR [mobile: add swarm connect to ipfs api](https://github.com/textileio/go-textile/pull/908) and set go-textile to v0.7.2 first

Additionally: Pass compile with `RepoPath -> BaseRepoPath` change in https://github.com/textileio/go-textile/commit/db375330e0e813f2c190caf3e604d3a775f06ded