### PR TITLE
ios-textile: add raw ipfs pubsub pub and sub from go-textile v0.7.6

### DIFF
--- a/Textile.podspec
+++ b/Textile.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   # https://stackoverflow.com/questions/50024087/gomobile-bind-producing-library-with-pie-disabled-i386-arch
   s.pod_target_xcconfig   = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1', 'OTHER_LDFLAGS[arch=i386]' => '-Wl,-read_only_relocs,suppress' }
   s.dependency 'Protobuf', '~> 3.7'
-  s.dependency 'TextileCore', '0.7.4'
+  s.dependency 'TextileCore', '0.7.6'
 end

--- a/Textile/Classes/Public/IpfsApi.h
+++ b/Textile/Classes/Public/IpfsApi.h
@@ -37,6 +37,29 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)dataAtPath:(NSString *)path completion:(void (^)(NSData * _Nullable, NSString * _Nullable, NSError * _Nonnull))completion;
 
+/**
+ * Publishes a message to a given pubsub topic
+ * @param topic The topic to publish to
+ * @param data The payload of message to publish
+ * @param error A reference to an error pointer that will be set in the case of an error
+ */
+- (void)pubsubPub:(NSString *)topic data:(NSString *)data error:(NSError **)error;
+
+/**
+ * Subscribes to messages on a given topic
+ * @param topic The ipfs pubsub sub topic
+ * @param error A reference to an error pointer that will be set in the case of an error
+ * @return A query ID that can be used to cancel the sub
+ */
+- (NSString *)pubsubSub:(NSString *)topic error:(NSError **)error;
+
+/**
+ * Cancel subscribe to messages on a given topic
+ * @param queryId The query ID that can be used to cancel the sub
+ * @param error A reference to an error pointer that will be set in the case of an error
+ */
+- (void)cancelPubsubSub:(NSString *)queryId error:(NSError **)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Textile/Classes/Public/IpfsApi.m
+++ b/Textile/Classes/Public/IpfsApi.m
@@ -32,4 +32,16 @@
   [self.node dataAtPath:path cb:cb];
 }
 
+- (void)pubsubPub:(NSString *)topic data:(NSString *)data error:(NSError * _Nullable __autoreleasing *)error {
+  [self.node ipfsPubsubPub:topic data:data error:error];
+}
+
+- (NSString *)pubsubSub:(NSString *)topic error:(NSError * _Nullable __autoreleasing *)error {
+  return [self.node ipfsPubsubSub:topic error:error];
+}
+
+- (void)cancelPubsubSub:(NSString *)queryId error:(NSError * _Nullable __autoreleasing *)error {
+  [self.node cancelIpfsPubsubSub:queryId error:error];
+}
+
 @end

--- a/Textile/Classes/Public/TextileDelegate.h
+++ b/Textile/Classes/Public/TextileDelegate.h
@@ -125,6 +125,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @optional
 /**
+ * Called when there is a message query result available
+ * @param queryId The id of the corresponding query
+ * @param message The message text
+ * @param messageId The id of the message
+ */
+- (void)pubsubQueryResult:(NSString *)queryId message:(NSString *)message messageId:(NSString *)messageId;
+
+@optional
+/**
  * Called when there is a thread query result available
  * @param queryId The id of the corresponding query
  * @param thread A thread query result

--- a/Textile/Classes/Services/Messenger.m
+++ b/Textile/Classes/Services/Messenger.m
@@ -105,7 +105,14 @@
       switch (queryEvent.type) {
         case MobileQueryEvent_Type_Data: {
           NSString *type = queryEvent.data_p.value.typeURL;
-          if ([type isEqualToString:@"/Thread"]) {
+          if ([type isEqualToString:@"/Strings"]) {
+            NSError *error;
+            NSString *message = [[[Strings alloc] initWithData:queryEvent.data_p.value.value error:&error].valuesArray firstObject];
+            NSString *messageId = queryEvent.data_p.id_p;
+            if (!error && [self.textile.delegate respondsToSelector:@selector(pubsubQueryResult:message:messageId:)]) {
+              [self.textile.delegate pubsubQueryResult:queryEvent.id_p message:message messageId:messageId];
+            }
+          } else if ([type isEqualToString:@"/Thread"]) {
             NSError *error;
             Thread *thread = [[Thread alloc] initWithData:queryEvent.data_p.value.value error:&error];
             if (!error && [self.textile.delegate respondsToSelector:@selector(clientThreadQueryResult:thread:)]) {


### PR DESCRIPTION
 Add raw ipfs pubsub pub and sub to [Expose simple p2p direct message API](https://github.com/textileio/go-textile/issues/885)

For easy PR review, there is no latest docs in this PR

Need PR [ipfs: add raw pubsub pub and sub to api and cmd and mobile](https://github.com/textileio/go-textile/pull/940) and set go-textile to v0.7.6 first